### PR TITLE
fix: update the release process to create the changelog content when make the release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "projex",
-  "version": "1.28.0",
+  "version": "1.29.5",
   "description": "A command line to manage the workflow",
   "keywords": [
     "cli",

--- a/src/modules/apps/git/release/changelog.ts
+++ b/src/modules/apps/git/release/changelog.ts
@@ -100,6 +100,11 @@ const getUnReleasedChanges = (changelogContent: string) => {
     result += line + '\n';
   }
 
+  if (!result || result == '') {
+    log.error(Colors.ERROR('no unreleased changes found, please check your commits.'));
+    process.exit(1);
+  }
+
   return result;
 };
 

--- a/src/modules/apps/git/release/changelog.ts
+++ b/src/modules/apps/git/release/changelog.ts
@@ -65,7 +65,7 @@ const getScopeInCommit = (commit: string) => {
 
   if (match) {
     const scope = match[0];
-    return scope ? `**${scope.replace(/[\(\)]/g, '')}**:` : '';
+    return scope ? `**${scope.replace(/[\(\)]/g, '')}**: ` : '';
   } else {
     return '';
   }
@@ -118,14 +118,17 @@ export const organizeCommitsToChangelog = (commits: string, originUrl: string) =
   unReleasedCommits.split('\n').forEach((commit) => {
     if (commit === '') return;
 
+    commit = commit.toLowerCase();
+
     const typeFixed = () => {
       let regex = /(fix)(\([\w\s]*\))?:\s*/;
       let match = commit.match(regex);
 
       if (match) {
+        const type = match[0];
         const scope = getScopeInCommit(commit);
         const commitWithPullRequestId = getPullRequestId(commit, originUrl);
-        fixes.push(commitWithPullRequestId.replace(match[0], scope));
+        fixes.push(commitWithPullRequestId.replace(type, scope));
         return true;
       }
       return false;
@@ -136,16 +139,17 @@ export const organizeCommitsToChangelog = (commits: string, originUrl: string) =
       let match = commit.match(regex);
 
       if (match) {
+        const type = match[0];
         const scope = getScopeInCommit(commit);
         const commitWithPullRequestId = getPullRequestId(commit, originUrl);
-        features.push(commitWithPullRequestId.replace(match[0], scope));
+        features.push(commitWithPullRequestId.replace(type, scope));
         return true;
       }
       return false;
     };
 
     const typeBreakingChange = () => {
-      let regex = /(fix|feat|build|ci|chore|docs|style|refactor|perf|test)(\([\w\s]*\))(!):\s*/;
+      let regex = /(fix|feat|build|ci|chore|docs|style|refactor|perf|test)(\([\w\s]*\))?(!):\s*/;
       let match = commit.match(regex);
 
       if (match) {

--- a/src/modules/apps/git/release/createRelease.ts
+++ b/src/modules/apps/git/release/createRelease.ts
@@ -32,7 +32,7 @@ export const release = async (
   const pushCommandText = pushCommand(tagText, noTag);
 
   if (getVersion) {
-    return console.log(utils.versionText(oldVersion, newVersion, pushCommandText));
+    return console.log(utils.getVersionInformation(oldVersion, newVersion, pushCommandText));
   }
 
   if (!preConfirm && !(await utils.confirmRelease(String(newVersion)))) {

--- a/src/modules/apps/git/release/utils.ts
+++ b/src/modules/apps/git/release/utils.ts
@@ -246,6 +246,7 @@ export class ReleaseUtils {
   public getRelease = (tagName: string) => {
     let releaseType: ReleaseType | null = tagName !== 'stable' ? 'prerelease' : null;
     let changelog: string = '';
+
     if (tagName === 'stable') {
       const commits = getGitCommits(this.root).toString();
       const changelogContent = organizeCommitsToChangelog(commits, getOriginUrl(this.root));
@@ -257,6 +258,7 @@ export class ReleaseUtils {
       log.error(Colors.ERROR(`invalid release type: ${tagName}`));
       process.exit(1);
     }
+
     const oldVersion = this.readVersion();
     const newVersion = this.incrementVersion(oldVersion, releaseType, tagName);
     // validate version
@@ -274,8 +276,12 @@ export class ReleaseUtils {
     };
   };
 
-  public versionText = (oldVersion: string, newVersion: string, pushCommandText: string) => {
-    const versionText = `old_version:${oldVersion},new_version:${newVersion},app_name:${this.readAppName()},push:${pushCommandText}`;
-    return versionText;
+  public getVersionInformation = (oldVersion: string, newVersion: string, pushCommandText: string) => {
+    return {
+      oldVersion,
+      newVersion,
+      pushCommandText,
+      appName: this.readAppName(),
+    };
   };
 }

--- a/src/shared/constants/commands.ts
+++ b/src/shared/constants/commands.ts
@@ -14,6 +14,8 @@ export const ERROR_TO_EXCLUDE = [
   'failed to install dependencies through yarn',
   'Connection to debug log server has failed with status',
   'Connection to event server has failed with',
+  'Error publishing app: Status 500 (try: 1)',
+  "Error publishing app: Status 500 (try: 2)",
   'ErrorID:',
 ];
 

--- a/src/shared/utils/git.ts
+++ b/src/shared/utils/git.ts
@@ -52,12 +52,12 @@ export const gitStatus = (root: string) => {
 };
 
 export const getGitCommits = (root: string) => {
-  return runCommand(`git rev-list HEAD --pretty=oneline`, root, '', true);
+  return runCommand(`git rev-list HEAD --pretty=oneline`, root, '', true, 0, true);
 };
 
 export const getTheLastTag = (root: string) => {
   try {
-    const tags = runCommand('git describe --tags --abbrev=0', root, '', true, 0, false, false);
+    const tags = runCommand('git describe --tags --abbrev=0', root, '', true, 0, true, false);
     if (tags) {
       return tags.toString();
     } else {
@@ -70,7 +70,7 @@ export const getTheLastTag = (root: string) => {
 };
 
 export const getOriginUrl = (root: string) => {
-  const url = runCommand(`git config --get remote.origin.url`, root, '', true)
+  const url = runCommand(`git config --get remote.origin.url`, root, '', true, 0, true)
     ?.toString()
     .replace('\n', '')
     .replace('.git', '');


### PR DESCRIPTION
#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

Se corrige la creación del changelog.md cuando se realiza el release y se cambia la forma en que se retorna la información del release al usar el flag `--get-version`

Se agregaron en los comandos de exclusión de error al hacer el uso del comando `projex vtex run` 
<img width="641" alt="image" src="https://github.com/Maik3345/projex-toolbet/assets/16216117/ab94d261-41ce-4dab-bb6b-40c40908e955">


#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://media.giphy.com/media/v1.Y2lkPTc5MGI3NjExaDQyNGdpMXB4YjVqeXM5ZmhwbTNjZ2VrYXk1ZDE1ZDByYXA2ajJ1OCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/26tPo9rksWnfPo4HS/giphy.gif)
