### PR TITLE
chore: add run-script command to execute scripts from manifest.json and change release process

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ You can see the list of commands with the command `projex --help` and you can se
 | `projex vtex cms backup`           | Download the files from the checkout files of a VTEX site                                                                                                                                |
 | `projex vtex cms deploy`           | Deploy local files in the checkout of the current account                                                                                                                                |
 | `projex vtex run`                  | Run a command and automatically accept any "Yes/No" questions by default.                                                                                                                |
+| `projex vtex run-script`           | Run a command from the manifest.json file, if the command not exist in this file pass to search in the package.json file default.                                                        |
 
 ## Manage the release version of your project
 
@@ -99,6 +100,8 @@ FLAGS
       --get-version       Only get the current version without performing any release actions.
       --no-check-release  Do not automatically check if the release is valid and does not have local changes.
       --no-deploy         Do not automatically run the preRelease script from the manifest file.
+      --no-post-release   Do not automatically run the postRelease script from the manifest file.
+      --no-pre-release    Do not automatically run the preRelease script from the manifest file.
       --no-push           Do not automatically push all changes to the remote repository.
       --no-tag            Do not automatically tag the release.
 

--- a/README.md
+++ b/README.md
@@ -97,13 +97,15 @@ FLAGS
   -h, --help              Shows this help message.
   -v, --verbose           Shows debug level logs.
   -y, --yes               Automatically answer yes to all prompts.
-      --get-version       Only get the current version without performing any release actions.
-      --no-check-release  Do not automatically check if the release is valid and does not have local changes.
-      --no-deploy         Do not automatically run the preRelease script from the manifest file.
-      --no-post-release   Do not automatically run the postRelease script from the manifest file.
-      --no-pre-release    Do not automatically run the preRelease script from the manifest file.
-      --no-push           Do not automatically push all changes to the remote repository.
-      --no-tag            Do not automatically tag the release.
+      --get-only-version-number  Get the version number only.
+      --get-release-type         Get the release type of the current version.
+      --get-version              Only get the current version without performing any release actions.
+      --no-check-release         Do not automatically check if the release is valid and does not have local changes.
+      --no-deploy                Do not automatically run the preRelease script from the manifest file.
+      --no-post-release          Do not automatically run the postRelease script from the manifest file.
+      --no-pre-release           Do not automatically run the preRelease script from the manifest file.
+      --no-push                  Do not automatically push all changes to the remote repository.
+      --no-tag                   Do not automatically tag the release.
 
 DESCRIPTION
   Bumps the app version, commits, and pushes the app to the remote repository (Only for git users).

--- a/src/commands/git/release.ts
+++ b/src/commands/git/release.ts
@@ -34,6 +34,14 @@ export default class Release extends Command {
       description: 'Do not automatically check if the release is valid and does not have local changes.',
       default: false,
     }),
+    'no-pre-release': Flags.boolean({
+      description: 'Do not automatically run the preRelease script from the manifest file.',
+      default: false,
+    }),
+    'no-post-release': Flags.boolean({
+      description: 'Do not automatically run the postRelease script from the manifest file.',
+      default: false,
+    }),
     'no-tag': Flags.boolean({
       description: 'Do not automatically tag the release.',
       default: false,
@@ -68,6 +76,8 @@ export default class Release extends Command {
         noCheckRelease: flags['no-check-release'],
         noTag: flags['no-tag'],
         getVersion: flags['get-version'],
+        noPreRelease: flags['no-pre-release'],
+        noPostRelease: flags['no-post-release'],
       },
       tagName,
     );

--- a/src/commands/git/release.ts
+++ b/src/commands/git/release.ts
@@ -50,6 +50,14 @@ export default class Release extends Command {
       description: 'Only get the current version without performing any release actions.',
       default: false,
     }),
+    'get-release-type': Flags.boolean({
+      description: 'Get the release type of the current version.',
+      default: false,
+    }),
+    'get-only-version-number': Flags.boolean({
+      description: 'Get the version number only.',
+      default: false,
+    }),
   };
 
   static args = {
@@ -78,6 +86,8 @@ export default class Release extends Command {
         getVersion: flags['get-version'],
         noPreRelease: flags['no-pre-release'],
         noPostRelease: flags['no-post-release'],
+        getReleaseType: flags['get-release-type'],
+        getOnlyVersionNumber: flags['get-only-version-number'],
       },
       tagName,
     );

--- a/src/commands/vtex/run-script.ts
+++ b/src/commands/vtex/run-script.ts
@@ -1,0 +1,30 @@
+import { Colors } from '@api';
+import { vtexRunScript } from '@modules';
+import { Args, Command } from '@oclif/core';
+import { CLI_NAME, globalFlags } from '@shared';
+
+export default class Browse extends Command {
+  static description = `Run a script from the package.json or the manifest.json file. If the script is not found, we throw a warning.`;
+
+  static examples = [
+    `${Colors.PINK(`${CLI_NAME} vtex run`)} 'vtex release minor stable'`,
+    `${Colors.PINK(`${CLI_NAME} vtex run`)} 'git status'`,
+  ];
+
+  static flags = {
+    ...globalFlags,
+  };
+
+  static args = {
+    script: Args.string({
+      description: `Specify the script to run.`,
+    }),
+  };
+
+  async run() {
+    const {
+      args: { script },
+    } = await this.parse(Browse);
+    vtexRunScript(script);
+  }
+}

--- a/src/modules/apps/git/release/createRelease.ts
+++ b/src/modules/apps/git/release/createRelease.ts
@@ -15,6 +15,8 @@ export const release = async (
     getVersion?: boolean;
     noPreRelease?: boolean;
     noPostRelease?: boolean;
+    getReleaseType?: boolean;
+    getOnlyVersionNumber?: boolean;
   },
   tagName: string,
 ) => {
@@ -26,6 +28,8 @@ export const release = async (
   const getVersion = options.getVersion;
   const noPreRelease = options.noPreRelease;
   const noPostRelease = options.noPostRelease;
+  const getReleaseType = options.getReleaseType;
+  const getOnlyVersionNumber = options.getOnlyVersionNumber;
 
   const utils = new ReleaseUtils();
 
@@ -35,40 +39,44 @@ export const release = async (
   const { releaseType, oldVersion, newVersion, tagText, changelogVersion, changelog } = utils.getRelease(tagName);
   const pushCommandText = pushCommand(tagText, noTag);
 
-  if (getVersion) {
+  if (getOnlyVersionNumber) {
+    return console.log(newVersion);
+  } else if (getReleaseType) {
+    return console.log(releaseType);
+  } else if (getVersion) {
     return console.log(utils.versionFileUtils.getVersionInformation(oldVersion, newVersion, pushCommandText));
-  }
-
-  if (!preConfirm && !(await utils.confirmRelease(String(newVersion)))) {
-    log.verbose('aborted release.');
-    return;
-  }
-
-  try {
-    await utils.preRelease({ noPreRelease, checkPreRelease });
-
-    await utils.versionFileUtils.bump(newVersion);
-
-    if (shouldUpdateChangelog(releaseType, tagName)) {
-      utils.updateChangelog(changelogVersion, changelog);
+  } else {
+    if (!preConfirm && !(await utils.confirmRelease(String(newVersion)))) {
+      log.verbose('aborted release.');
+      return;
     }
 
-    if (!pushAutomatic) {
-      await utils.versionFileUtils.add();
-      await utils.commit(tagText, releaseType);
+    try {
+      await utils.preRelease({ noPreRelease, checkPreRelease });
+
+      await utils.versionFileUtils.bump(newVersion);
+
+      if (shouldUpdateChangelog(releaseType, tagName)) {
+        utils.updateChangelog(changelogVersion, changelog);
+      }
+
+      if (!pushAutomatic) {
+        await utils.versionFileUtils.add();
+        await utils.commit(tagText, releaseType);
+      }
+      if (!noTag) {
+        await tag(tagText, utils.versionFileUtils.root);
+      }
+      if (!pushAutomatic) {
+        await utils.push(tagText, noTag);
+      }
+      if (!automaticDeploy) {
+        await utils.postRelease(noPostRelease);
+      }
+    } catch (e) {
+      log.error(`${Colors.ERROR('an error occurred while releasing the new version')} ${chalk.bold(newVersion)}.`);
+      log.error(e);
+      process.exit(1);
     }
-    if (!noTag) {
-      await tag(tagText, utils.versionFileUtils.root);
-    }
-    if (!pushAutomatic) {
-      await utils.push(tagText, noTag);
-    }
-    if (!automaticDeploy) {
-      await utils.postRelease(noPostRelease);
-    }
-  } catch (e) {
-    log.error(`${Colors.ERROR('an error occurred while releasing the new version')} ${chalk.bold(newVersion)}.`);
-    log.error(e);
-    process.exit(1);
   }
 };

--- a/src/modules/apps/git/release/utils.ts
+++ b/src/modules/apps/git/release/utils.ts
@@ -8,88 +8,33 @@ import {
   pushCommand,
   runCommand,
   unreleased,
+  VersionFileUtils,
 } from '@shared';
-import { close, existsSync, openSync, readFileSync, readJsonSync, writeJsonSync, writeSync } from 'fs-extra';
-import { resolve } from 'path';
-import { ReleaseType, inc, valid } from 'semver';
-import { validateVersion, organizeCommitsToChangelog } from './changelog';
-const fs = require('fs');
+import { close, existsSync, openSync, readFileSync, writeSync } from 'fs-extra';
+import { ReleaseType } from 'semver';
+import { organizeCommitsToChangelog, validateVersion } from './changelog';
 const chalk = require('chalk');
 
 export class ReleaseUtils {
-  public root: string;
-  private manifestVersionFile: string;
-  private packageVersionFile: string;
-  private versionFile: string = '';
-  private changelogPath: string;
+  public versionFileUtils = new VersionFileUtils();
 
-  constructor() {
-    this.root = getAppRoot();
-    this.manifestVersionFile = resolve(this.root, 'manifest.json');
-    this.packageVersionFile = resolve(this.root, 'package.json');
-
-    this.changelogPath = resolve(this.root, 'CHANGELOG.md');
-  }
-
-  public checkDirectory = (repository: string) => {
-    try {
-      return fs.existsSync(repository);
-    } catch (error) {
-      return false;
-    }
-  };
-
-  private readVersionFile = () => {
-    if (this.checkDirectory(this.manifestVersionFile)) {
-      this.versionFile = this.manifestVersionFile;
-      return readJsonSync(this.manifestVersionFile);
-    } else if (this.checkDirectory(this.packageVersionFile)) {
-      this.versionFile = this.packageVersionFile;
-      return readJsonSync(this.packageVersionFile);
-    } else {
-      log.error(
-        `${Colors.ERROR('version file not found:')} ${this.manifestVersionFile} or ${this.packageVersionFile}.`,
-      );
-      process.exit(1);
-    }
-  };
-
-  private writeVersionFile = (newManifest: any) => {
-    writeJsonSync(this.versionFile, newManifest, { spaces: 2 });
-  };
-
-  public readVersion = () => {
-    const version = valid(this.readVersionFile().version, true);
-    if (!version) {
-      log.error(Colors.ERROR(`invalid app version: ${version}`));
-      process.exit(1);
-    }
-    return version;
-  };
-
-  public incrementVersion = (rawOldVersion: string, releaseType: ReleaseType, tagName?: string) => {
-    const oldVersion = valid(rawOldVersion, true);
-    if (tagName !== 'stable' && releaseType !== 'prerelease') {
-      return inc(String(oldVersion), `pre${releaseType}` as ReleaseType, false, tagName);
-    }
-    return inc(String(oldVersion), releaseType);
-  };
+  constructor() {}
 
   public commit = (tagName: string, releaseType: string) => {
     const beta = releaseType === 'prerelease' || releaseType === 'pre';
     const commitIcon = beta ? 'chore(beta): beta release' : 'chore(main): release';
     const commitMessage = `${commitIcon} ${tagName}`;
-    let successMessage = `file(s) ${this.versionFile} committed`;
-    if (existsSync(this.changelogPath)) {
-      successMessage = `files ${this.versionFile} ${this.changelogPath} committed`;
+    let successMessage = `file(s) ${this.versionFileUtils.versionFile} committed`;
+    if (existsSync(this.versionFileUtils.changelogPath)) {
+      successMessage = `files ${this.versionFileUtils.versionFile} ${this.versionFileUtils.changelogPath} committed`;
     }
-    return runCommand(`git commit -m "${commitMessage}"`, this.root, successMessage, true);
+    return runCommand(`git commit -m "${commitMessage}"`, this.versionFileUtils.root, successMessage, true);
   };
 
   public push = (tagName: string, noTag: boolean | undefined) => {
     return runCommand(
       pushCommand(tagName, noTag),
-      this.root,
+      this.versionFileUtils.root,
       `pushed commit ${noTag ? '' : `and tag ${tagName}`}`,
       true,
       2,
@@ -97,28 +42,40 @@ export class ReleaseUtils {
   };
 
   public checkNothingToCommit = () => {
-    const response = gitStatus(this.root).toString();
+    const response = gitStatus(this.versionFileUtils.root).toString();
     return !response;
   };
 
   public checkIfGitPushWorks = () => {
     try {
-      runCommand('git push', this.root, '', true, 2, true);
+      runCommand('git push', this.versionFileUtils.root, '', true, 2, true);
     } catch (e) {
       log.error(Colors.ERROR(`failed pushing to remote. ${e}`));
     }
   };
 
-  /* The `preRelease` method is a function that is used to perform pre-release tasks before creating a
-  new release. Here is a breakdown of what it does: */
-  public preRelease = () => {
-    if (!this.checkNothingToCommit()) {
-      log.warn(
-        chalk.red(
-          'process could not continue because there are uncommitted changes, Please commit your changes before proceeding.',
-        ),
-      );
-      process.exit(1);
+  public preRelease = async ({
+    checkPreRelease,
+    noPreRelease,
+  }: {
+    noPreRelease?: boolean;
+    checkPreRelease?: boolean;
+  }) => {
+    if (!checkPreRelease) {
+      if (!this.checkNothingToCommit()) {
+        log.warn(
+          chalk.red(
+            'process could not continue because there are uncommitted changes, Please commit your changes before proceeding.',
+          ),
+        );
+        process.exit(1);
+      }
+    }
+
+    if (noPreRelease) return;
+
+    if (this.versionFileUtils.findScript('prerelease')) {
+      return await this.versionFileUtils.runFindScript('prerelease', 'pre release');
     }
   };
 
@@ -133,37 +90,23 @@ export class ReleaseUtils {
     return true;
   };
 
-  public postRelease = () => {
+  public postRelease = (noPostRelease?: boolean) => {
+    if (noPostRelease) return;
+
     const msg = 'post release';
-    if (this.getScript('postrelease')) {
-      return this.runScript('postrelease', msg);
+    if (this.versionFileUtils.findScript('postrelease')) {
+      return this.versionFileUtils.runFindScript('postrelease', msg);
     }
-    if (this.getScript('postreleasy')) {
-      return this.runScript('postreleasy', msg);
+    if (this.versionFileUtils.findScript('postreleasy')) {
+      return this.versionFileUtils.runFindScript('postreleasy', msg);
     }
-  };
-
-  public add = () => {
-    let gitAddCommand = `git add "${this.versionFile}"`;
-    let successMessage = `file ${this.versionFile} added`;
-    if (existsSync(this.changelogPath)) {
-      gitAddCommand += ` "${this.changelogPath}"`;
-      successMessage = `files ${this.versionFile} ${this.changelogPath} added`;
-    }
-    return runCommand(gitAddCommand, this.root, successMessage, true);
-  };
-
-  public readAppName = () => {
-    const vendor = this.readVersionFile().vendor;
-    const name = this.readVersionFile().name;
-    return `${vendor ? `${vendor}.` : ''}${name}`;
   };
 
   public updateChangelog = (changelogVersion: string, changelog: string) => {
-    if (existsSync(this.changelogPath)) {
+    if (existsSync(this.versionFileUtils.changelogPath)) {
       let data: string;
       try {
-        data = readFileSync(this.changelogPath).toString();
+        data = readFileSync(this.versionFileUtils.changelogPath).toString();
       } catch (e) {
         log.error(`error reading file: ${e}`);
         process.exit(1);
@@ -179,7 +122,7 @@ export class ReleaseUtils {
       } else {
         const position = data.indexOf(unreleased) + unreleased.length;
         const bufferedText = Buffer.from(`${changelogVersion}\n${changelog}${data.substring(position)}`);
-        const file = openSync(this.changelogPath, 'r+');
+        const file = openSync(this.versionFileUtils.changelogPath, 'r+');
         try {
           writeSync(file, bufferedText, 0, bufferedText.length, position);
           close(file);
@@ -192,26 +135,9 @@ export class ReleaseUtils {
     }
   };
 
-  public bump = (newVersion: string) => {
-    const content = this.readVersionFile();
-    content.version = newVersion;
-    this.writeVersionFile(content);
-    log.info(`bumped version to ${chalk.bold.green(newVersion)}`);
-  };
-
-  private getScript = (key: string): string => {
-    const versionFile = this.readVersionFile();
-    return versionFile.scripts && versionFile.scripts[key];
-  };
-
-  private runScript = (key: string, msg: string) => {
-    const cmd: string = this.getScript(key);
-    return cmd ? runCommand(cmd, this.root, msg, false) : undefined;
-  };
-
   private getChangelogDate = (newVersion: string) => {
-    const lastTag = getTheLastTag(this.root);
-    const originUrl = getOriginUrl(this.root);
+    const lastTag = getTheLastTag(this.versionFileUtils.root);
+    const originUrl = getOriginUrl(this.versionFileUtils.root);
     let compareTagUrl = '';
 
     if (lastTag) {
@@ -248,8 +174,8 @@ export class ReleaseUtils {
     let changelog: string = '';
 
     if (tagName === 'stable') {
-      const commits = getGitCommits(this.root).toString();
-      const changelogContent = organizeCommitsToChangelog(commits, getOriginUrl(this.root));
+      const commits = getGitCommits(this.versionFileUtils.root).toString();
+      const changelogContent = organizeCommitsToChangelog(commits, getOriginUrl(this.versionFileUtils.root));
       releaseType = releaseType ? releaseType : changelogContent.releaseType;
       changelog = changelogContent.changelog;
     }
@@ -259,8 +185,8 @@ export class ReleaseUtils {
       process.exit(1);
     }
 
-    const oldVersion = this.readVersion();
-    const newVersion = this.incrementVersion(oldVersion, releaseType, tagName);
+    const oldVersion = this.versionFileUtils.readVersion();
+    const newVersion = this.versionFileUtils.incrementVersion(oldVersion, releaseType, tagName);
     // validate version
     validateVersion(oldVersion, releaseType, tagName);
     const tagText = `v${newVersion}`;
@@ -273,15 +199,6 @@ export class ReleaseUtils {
       tagText,
       changelogVersion,
       changelog,
-    };
-  };
-
-  public getVersionInformation = (oldVersion: string, newVersion: string, pushCommandText: string) => {
-    return {
-      oldVersion,
-      newVersion,
-      pushCommandText,
-      appName: this.readAppName(),
     };
   };
 }

--- a/src/modules/apps/vtex/index.ts
+++ b/src/modules/apps/vtex/index.ts
@@ -1,3 +1,4 @@
-export * from "./cms";
-export * from "./login";
-export * from "./run";
+export * from './cms';
+export * from './login';
+export * from './run';
+export * from './run-script';

--- a/src/modules/apps/vtex/run-script/index.ts
+++ b/src/modules/apps/vtex/run-script/index.ts
@@ -1,0 +1,11 @@
+import { log, VersionFileUtils } from '@shared';
+
+export const vtexRunScript = async function (script: string | undefined) {
+  if (script === undefined) {
+    return log.error('no script to execute');
+  }
+
+  const { runFindScript } = new VersionFileUtils();
+
+  runFindScript(script, 'running script');
+};

--- a/src/shared/constants/commands.ts
+++ b/src/shared/constants/commands.ts
@@ -15,7 +15,8 @@ export const ERROR_TO_EXCLUDE = [
   'Connection to debug log server has failed with status',
   'Connection to event server has failed with',
   'Error publishing app: Status 500 (try: 1)',
-  "Error publishing app: Status 500 (try: 2)",
+  'Error publishing app: Status 500 (try: 2)',
+  'Publishing failed.',
   'ErrorID:',
 ];
 

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -10,3 +10,4 @@ export * from './prompts';
 export * from './runCommand';
 export * from './runMultipleCommand';
 export * from './runOnlyCommand';
+export * from './versionFile';

--- a/src/shared/utils/runCommand.ts
+++ b/src/shared/utils/runCommand.ts
@@ -40,11 +40,11 @@ export const runCommand = (
       cwd,
     });
     if (!hideSuccessMessage) {
-      log.warn(Colors.BLUE(`running command: ${Colors.WARNING(chalk.bold(cmd))}`));
+      log.verbose(Colors.BLUE(`running command: ${Colors.WARNING(chalk.bold(cmd))}`));
     }
     return output;
   } catch (e: any) {
-    log.error(`${Colors.ERROR('error running command:')} ${Colors.WHITE(`${chalk.bold(cmd)} in ${chalk.bold(cwd)}`)}`);
+    log.verbose(`${Colors.ERROR('error:')} ${Colors.WHITE(`${chalk.bold(cmd)} in ${chalk.bold(cwd)}`)}`);
     if (!makeThrow) {
       return;
     }
@@ -52,7 +52,7 @@ export const runCommand = (
     if (retries <= 0) {
       throw e;
     }
-    log.info(`retrying command: ${chalk.bold(cmd)} in ${chalk.bold(cwd)}`);
+    log.verbose(`retrying command: ${chalk.bold(cmd)} in ${chalk.bold(cwd)}`);
 
     return runCommand(cmd, cwd, successMessage, hideOutput, retries - 1, hideSuccessMessage);
   }

--- a/src/shared/utils/versionFile.ts
+++ b/src/shared/utils/versionFile.ts
@@ -1,0 +1,166 @@
+import { Colors, getAppRoot } from '@api';
+import { log, runCommand } from '@shared';
+import { existsSync, readJsonSync, writeJsonSync } from 'fs-extra';
+import { inc, ReleaseType, valid } from 'semver';
+
+import { resolve } from 'path';
+const fs = require('fs');
+const chalk = require('chalk');
+
+interface VersionFileContent {
+  version: string;
+  scripts: {
+    [key: string]: string;
+  };
+}
+
+export class VersionFileUtils {
+  public root: string;
+  public manifestVersionFile: string;
+  public packageVersionFile: string;
+  public manifestFile: string = '';
+  public packageFile: string = '';
+  public manifestContent: VersionFileContent | null = null;
+  public packageJsonContent: VersionFileContent | null = null;
+  public versionFile: string = '';
+  public versionContent: any = null;
+  public changelogPath: string;
+
+  constructor() {
+    this.root = getAppRoot();
+    this.manifestVersionFile = resolve(this.root, 'manifest.json');
+    this.packageVersionFile = resolve(this.root, 'package.json');
+    this.changelogPath = resolve(this.root, 'CHANGELOG.md');
+    this.readVersionFile();
+  }
+
+  public checkDirectory = (repository: string) => {
+    try {
+      return fs.existsSync(repository);
+    } catch (error) {
+      return false;
+    }
+  };
+
+  private readVersionFile = () => {
+    if (this.checkDirectory(this.manifestVersionFile)) {
+      this.manifestFile = this.manifestVersionFile;
+      this.manifestContent = readJsonSync(this.manifestVersionFile);
+    }
+    if (this.checkDirectory(this.packageVersionFile)) {
+      this.packageFile = this.packageVersionFile;
+      this.packageJsonContent = readJsonSync(this.packageVersionFile);
+    }
+
+    if (!this.manifestContent && !this.packageJsonContent) {
+      log.error(
+        `${Colors.ERROR('version file not found:')} ${this.manifestVersionFile} or ${this.packageVersionFile}.`,
+      );
+      process.exit(1);
+    }
+
+    this.versionFile = this.manifestFile || this.packageFile;
+    this.versionContent = this.manifestContent || this.packageJsonContent;
+  };
+
+  public writeVersionFile = (newVersion: string) => {
+    const contentPackageJson = this.packageJsonContent;
+    const contentManifest = this.manifestContent;
+
+    if (contentPackageJson) {
+      contentPackageJson.version = newVersion;
+      writeJsonSync(this.packageFile, contentPackageJson, { spaces: 2 });
+    }
+
+    if (contentManifest) {
+      contentManifest.version = newVersion;
+      writeJsonSync(this.manifestFile, contentManifest, { spaces: 2 });
+    }
+  };
+
+  public readVersion = () => {
+    const version = valid(this.versionContent?.version, true);
+    if (!version) {
+      log.error(Colors.ERROR(`invalid app version: ${version}`));
+      process.exit(1);
+    }
+    return version;
+  };
+
+  public incrementVersion = (rawOldVersion: string, releaseType: ReleaseType, tagName?: string) => {
+    const oldVersion = valid(rawOldVersion, true);
+    if (tagName !== 'stable' && releaseType !== 'prerelease') {
+      return inc(String(oldVersion), `pre${releaseType}` as ReleaseType, false, tagName);
+    }
+    return inc(String(oldVersion), releaseType);
+  };
+
+  public bump = (newVersion: string) => {
+    this.writeVersionFile(newVersion);
+    log.info(`bumped version to ${chalk.bold.green(newVersion)}`);
+  };
+
+  public add = () => {
+    let gitAddCommand = `git add "${this.versionFile}"`;
+    let successMessage = `file ${this.versionFile} added`;
+    if (existsSync(this.changelogPath)) {
+      gitAddCommand += ` "${this.changelogPath}"`;
+      successMessage = `files ${this.versionFile} ${this.changelogPath} added`;
+    }
+    return runCommand(gitAddCommand, this.root, successMessage, true);
+  };
+
+  private getVersionFileToUse = () => {
+    return this.manifestContent || this.packageJsonContent;
+  };
+
+  public readAppName = () => {
+    const vendor = this.versionContent?.vendor;
+    const name = this.versionContent?.name;
+    return `${vendor ? `${vendor}.` : ''}${name}`;
+  };
+
+  private getScript = (key: string): string => {
+    const versionFile = this.getVersionFileToUse();
+    if (!versionFile) {
+      log.error('no version file found');
+      process.exit(1);
+    }
+
+    return versionFile.scripts && versionFile.scripts[key];
+  };
+
+  public findScript = (key: string) => {
+    if (this.manifestContent || this.packageJsonContent) {
+      const scriptInManifestFile = this.manifestContent?.scripts && this.manifestContent?.scripts[key];
+      const scriptInPackageFile = this.packageJsonContent?.scripts && this.packageJsonContent?.scripts[key];
+
+      if (scriptInManifestFile) {
+        return scriptInManifestFile;
+      } else if (scriptInPackageFile) {
+        return scriptInPackageFile;
+      } else {
+        log.warn(`no script found for ${key}`);
+      }
+    }
+  };
+
+  public runFindScript = (key: string, msg: string) => {
+    const cmd = this.findScript(key);
+    return cmd ? runCommand(cmd, this.root, msg, false) : log.warn(`no script found for ${key}`);
+  };
+
+  public runScript = (key: string, msg: string) => {
+    const cmd: string = this.getScript(key);
+    return cmd ? runCommand(cmd, this.root, msg, false) : log.warn(`no script found for ${key}`);
+  };
+
+  public getVersionInformation = (oldVersion: string, newVersion: string, pushCommandText: string) => {
+    return {
+      oldVersion,
+      newVersion,
+      pushCommandText,
+      appName: this.readAppName(),
+    };
+  };
+}


### PR DESCRIPTION
#### What problem is this solving?

**ejecutar scripts del manifest**: se crea el comando `projex vtex run-scripts #scriptToUse` to execute the script from the manifest.json file, if the command is not found in this files pass to search in the scripts of the package.json
**release refactor**: add the tag `--no-post-release`and `--no-pre-release` to prevent the execution of this stages in the release process. and add the execution of the script `prerelease` in the initial process of the release to make any action before of the release process. 
**crear nuevos flags para el release**:  se crearon los flags 

```
--get-only-version-number  Get the version number only.
--get-release-type         Get the release type of the current version.
```

estos flags permiten obtener el tipo de release y el valor de la versión a desplegar


<!--- What is the motivation and context for this change? -->

In the CI/CD process if you need to make any action before of the process is necesary make this execution of the script `prerelease`

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExdzV5eWp0Zjd4d3I5czFncHRuNWV5aTljMG54bXdhaXkydDk3cDA0bCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/ienko7tUwlgz86igqU/giphy.gif)
