### PR TITLE
refactor: improve regex to capture merged pull request ID with optional colon

### DIFF
--- a/src/modules/apps/git/release/changelog.ts
+++ b/src/modules/apps/git/release/changelog.ts
@@ -95,12 +95,12 @@ const normalizeCommit = (commits: string[], originUrl: string, section: Changelo
 };
 
 const getScopeInCommit = (commit: string) => {
-  let regex = /\(([\w\s]*)\)/;
+  let regex = /\(([\w\s-]*)\)/;
   let match = commit.match(regex);
 
   if (match) {
-    const scope = match[0];
-    return scope ? `**${scope.replace(/[\(\)]/g, '')}**: ` : '';
+    const scope = match[1];
+    return scope ? `**${scope}**: ` : '';
   } else {
     return '';
   }
@@ -109,7 +109,7 @@ const getScopeInCommit = (commit: string) => {
 const getPullRequestLink = (originUrl: string, pullRequestId: string) => {
   let page = '';
   if (originUrl.includes('github')) {
-    return 'pull';
+    page = 'pull';
   } else {
     page = 'pullrequest';
   }


### PR DESCRIPTION
Se modifica la expresión regular para soportar el problema reportado en el issue #10 y se corrige la forma en que se crea la url del pull request para el escenario de github

#### What problem is this solving?

<!--- What is the motivation and context for this change? -->

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](https://i.giphy.com/media/v1.Y2lkPTc5MGI3NjExeXp2aWNyem13eGN5b3pmN3dya3NxYmNxZDI1Z2UwbHhqMmFob3VvNCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/fUQ4rhUZJYiQsas6WD/giphy.gif)
