### PR TITLE
feat: add timeout in the fail execution of `projex vtex run` command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "projex",
-  "version": "1.41.0",
+  "version": "1.41.1-0",
   "description": "A command line to manage the workflow",
   "keywords": [
     "cli",

--- a/src/commands/vtex/run-script.ts
+++ b/src/commands/vtex/run-script.ts
@@ -6,10 +6,7 @@ import { CLI_NAME, globalFlags } from '@shared';
 export default class Browse extends Command {
   static description = `Run a script from the package.json or the manifest.json file. If the script is not found, we throw a warning.`;
 
-  static examples = [
-    `${Colors.PINK(`${CLI_NAME} vtex run`)} 'vtex release minor stable'`,
-    `${Colors.PINK(`${CLI_NAME} vtex run`)} 'git status'`,
-  ];
+  static examples = [`${Colors.PINK(`${CLI_NAME} vtex run-script`)} 'prerelease'`];
 
   static flags = {
     ...globalFlags,

--- a/src/commands/vtex/run.ts
+++ b/src/commands/vtex/run.ts
@@ -8,7 +8,8 @@ export default class Browse extends Command {
 
   static examples = [
     `${Colors.PINK(`${CLI_NAME} vtex run`)} 'vtex release minor stable'`,
-    `${Colors.PINK(`${CLI_NAME} vtex run`)} 'git status'`,
+    `${Colors.PINK(`${CLI_NAME} vtex run`)} 'vtex publish'`,
+    `${Colors.PINK(`${CLI_NAME} vtex run`)} 'vtex deploy'`,
   ];
 
   static flags = {

--- a/src/modules/apps/vtex/run/utils.ts
+++ b/src/modules/apps/vtex/run/utils.ts
@@ -50,8 +50,11 @@ export const childProcessRunCommandRun = function (command: string) {
     if (excludeError) return;
 
     if (checkErrors()) {
-      log.error(`finish with errors on run the command`);
-      throw new Error('finish execution with errors');
+      setTimeout(() => {
+        log.error(`finish with errors on run the command`);
+        throw new Error('finish execution with errors');
+      }, 5000);
+      return;
     }
   };
 


### PR DESCRIPTION
#### What problem is this solving?

Se agregó un timeout a la hora de detectar un error para que se logrén ver los demás logs que puedan salir, se puso a 5000 ms.

<!--- What is the motivation and context for this change? -->

Al hacer el proceso de publicación en un pipeline no se podía ver todo el mensaje de error ya que el throw que se ejecutaba salia de una y no daba tiempo a ver los demás errores

#### Screenshots or example usage:
![image](https://github.com/user-attachments/assets/385f252f-6909-49e4-9e67-c9f688b6ec4f)

<!--- Add some images or gifs to showcase changes in behaviour or layout. Example: before and after images -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
